### PR TITLE
[피클상세] 피클 상세 페이지 api연동 및 404페이지 추가

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -16,6 +16,7 @@ import LoginRedirector from './redirectors/LoginRedirector';
 import SignIn from './pages/auth/SignIn';
 import SignIn_Email from './pages/auth/SignIn_Email';
 import MainLayout from '@/layouts/MainLayout';
+import NotFoundPage from '@/pages/NotFoundPage';
 
 const privateChildren = [
   {
@@ -40,7 +41,7 @@ const router = createBrowserRouter([
   {
     path: '',
     element: <MainLayout />,
-    // errorElement: <NotFound />,
+    errorElement: <NotFoundPage />,
     children: [
       {
         path: routes.home,
@@ -51,7 +52,7 @@ const router = createBrowserRouter([
         element: <Pickle />,
       },
       {
-        path: routes.pickleList,
+        path: `${routes.pickleList}/:pickleId`,
         element: <PickleList />,
       },
       {

--- a/src/apis/pickle.api.ts
+++ b/src/apis/pickle.api.ts
@@ -3,11 +3,13 @@ import { API, API_PICKLE } from '@/constants/API';
 import { Coordinates, CreatePickleData } from './types/pickles.type';
 
 export const picklesRequests = Object.freeze({
+  // 피클 전체 목록조회
   getWithPage: async () => {
     const { data } = await client.get(API.PICKLE);
     return data;
   },
 
+  // 가까운 피클
   getNearby: async (location: Coordinates | null) => {
     if (location === null) return null;
     const { data } = await client.get(API_PICKLE.NEARBY, {
@@ -19,9 +21,15 @@ export const picklesRequests = Object.freeze({
     return data;
   },
 
+  // 피클 생성
   createPickle: async (pickleData: CreatePickleData) => {
     const { data } = await client.post(API_PICKLE.CREATE, pickleData);
     return data;
+  },
+
+  // 피클 상세조회
+  getPickleDetail: (pickleId: string) => {
+    return client.get(API_PICKLE.BY_ID(pickleId));
   },
 });
 

--- a/src/components/picklecard/WholePickleCard.tsx
+++ b/src/components/picklecard/WholePickleCard.tsx
@@ -1,28 +1,32 @@
+import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 
+import routes from '@/constants/routes';
 import { When } from '@/apis/types/pickles.type';
+import { formatCurrency } from '@/utils/formatData';
 import CategoryExercise from '@/assets/images/pickleCategoryImg-exercise.png';
 import CategoryStudy from '@/assets/images/pickleCategoryImg-study.png';
 
 interface WholePickleCardProps {
   type: 'study' | 'exercise';
+  id: string;
   title: string;
   when: When;
   cost: number;
 }
 
-export default function WholePickleCard({ type, title, when, cost }: WholePickleCardProps) {
+export default function WholePickleCard({ id: pickleId, type, title, when, cost }: WholePickleCardProps) {
   return (
-    <S.CardLayer $backImgType={type}>
+    <S.CardLayer to={`${routes.pickleList}/${pickleId}`} $backImgType={type}>
       <S.ProgressDay>{when.summary}</S.ProgressDay>
       <S.Title>{title}</S.Title>
-      <S.Price>{cost.toLocaleString('ko-KR')}원</S.Price>
+      <S.Price>{formatCurrency(cost)}원</S.Price>
     </S.CardLayer>
   );
 }
 
 const S = {
-  CardLayer: styled.a<{ $backImgType: 'study' | 'exercise' }>`
+  CardLayer: styled(Link)<{ $backImgType: 'study' | 'exercise' }>`
     display: block;
     /* width: 15rem; */
     height: 10.7rem;
@@ -36,6 +40,7 @@ const S = {
       $backImgType === 'study' ? `url(${CategoryStudy})` : `url(${CategoryExercise})`};
     background-repeat: no-repeat;
     background-position: bottom 15px right 0;
+    cursor: pointer;
   `,
   ProgressDay: styled.span`
     display: inline-block;

--- a/src/hooks/query/pickles/index.ts
+++ b/src/hooks/query/pickles/index.ts
@@ -1,8 +1,8 @@
 import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
 
 import { picklesRequests } from '@/apis/pickle.api';
 import { Coordinates, CreatePickleData } from '@/apis/types/pickles.type';
-import toast from 'react-hot-toast';
 
 export const useGetInfinitePickles = () => {
   return useInfiniteQuery({
@@ -38,6 +38,15 @@ export const useCreatePickleMutation = (pickleData: CreatePickleData) => {
     onError: error => {
       console.error(error);
       toast.error('피클 생성에 실패했습니다.');
+    },
+  });
+};
+
+export const useGetPickelDetail = (pickleId: string) => {
+  return useQuery({
+    queryKey: ['pickles', pickleId],
+    queryFn: async () => {
+      return await picklesRequests.getPickleDetail(pickleId);
     },
   });
 };

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,65 @@
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+
+//Todo : 임시제작! 디자인 생기면 수정
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+
+  return (
+    <S.Container>
+      <S.Error>404🥒</S.Error>
+      <div className="message">
+        요청하신 페이지를 찾을 수 없습니다...🥹
+        <br />
+      </div>
+      <S.GoBack
+        onClick={() => {
+          navigate(-1);
+        }}
+      >
+        이전 페이지로 돌아가기
+      </S.GoBack>
+    </S.Container>
+  );
+}
+
+const S = {
+  Container: styled.div`
+    width: 100%;
+    height: 100%;
+    padding-top: 22rem;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    .message {
+      font-size: 1.8rem;
+      color: #777;
+    }
+  `,
+
+  Error: styled.div`
+    padding-bottom: 2rem;
+    font-size: 14rem;
+    font-weight: 600;
+  `,
+
+  GoBack: styled.button`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    padding: 1.2rem;
+    margin-top: 5rem;
+    border: 1px solid #5dc26d;
+    border-radius: 0.8rem;
+    font-size: 1.6rem;
+    font-weight: 500;
+    background-color: #f7f9f7;
+
+    &:hover {
+      background-color: #5dc26d;
+    }
+  `,
+};

--- a/src/pages/pickles/PickleList.tsx
+++ b/src/pages/pickles/PickleList.tsx
@@ -4,6 +4,7 @@ import HeartButton from '@/components/common/button/HeartButton';
 import { useGetPickelDetail } from '@/hooks/query/pickles';
 import useHeartButtonClick from '@/hooks/useHeartButtonClick';
 import routes from '@/constants/routes';
+import { formatCurrency } from '@/utils/formatData';
 
 /**
  * 피클 상세 페이지
@@ -27,7 +28,7 @@ export default function PickleList() {
       <div>
         <p>우리 스터디는 {pickleDetailData?.title}야.</p>
         <p>{pickleDetailData?.capacity}명 모집할거고</p>
-        <p>참가비 {pickleDetailData?.cost}원이고</p>
+        <p>참가비는 {formatCurrency(pickleDetailData?.cost)}원이고</p>
         <p>
           총 {pickleDetailData?.when.summary}, {pickleDetailData?.where}에서 진행해
         </p>

--- a/src/pages/pickles/PickleList.tsx
+++ b/src/pages/pickles/PickleList.tsx
@@ -1,22 +1,39 @@
-import { useEffect, useState } from "react";
+import { useNavigate, useParams } from 'react-router-dom';
 
+import HeartButton from '@/components/common/button/HeartButton';
+import { useGetPickelDetail } from '@/hooks/query/pickles';
+import useHeartButtonClick from '@/hooks/useHeartButtonClick';
+import routes from '@/constants/routes';
+
+/**
+ * 피클 상세 페이지
+ */
+//Todo: 디자인 나오면 데이터활용해서 ui 구성
 export default function PickleList() {
-  const[pickles, setPickles] = useState<{id: string, name: string}[]>([]);
-  async function handleFetch() {
-    const response = await fetch("/api/pickles");
-    const result = await response.json();
-    setPickles(result);
-  }
-  useEffect(() => {
-    handleFetch();
-  }, []);
+  const navigate = useNavigate();
+  const { pickleId = '' } = useParams();
+
+  const { data } = useGetPickelDetail(pickleId);
+  const pickleDetailData = data?.data;
+
+  const { isHeartClicked, handleHeartClick } = useHeartButtonClick({
+    pickleId,
+    isInUserWishList: false,
+  });
+
   return (
-    <div>
-       {pickles.map((pickle) => (
-        <div key={pickle.id}>
-          <h2>{pickle.name}</h2>
-          </div>
-      ))}
-    </div>
+    <>
+      안녕피클상세임
+      <div>
+        <p>우리 스터디는 {pickleDetailData?.title}야.</p>
+        <p>{pickleDetailData?.capacity}명 모집할거고</p>
+        <p>참가비 {pickleDetailData?.cost}원이고</p>
+        <p>
+          총 {pickleDetailData?.when.summary}, {pickleDetailData?.where}에서 진행해
+        </p>
+      </div>
+      <HeartButton isActive={isHeartClicked} onClick={handleHeartClick} />
+      <button onClick={() => navigate(routes.pickle)}>참여하기</button>
+    </>
   );
 }

--- a/src/pages/profile/MyPage.tsx
+++ b/src/pages/profile/MyPage.tsx
@@ -1,7 +1,5 @@
 import SortButtons from '@/components/common/button/SortButtons';
 import InfinitePickleCardList from '@/components/picklecard/InfinitePickleCardList';
-import WholePickleCard from '@/components/picklecard/WholePickleCard';
-import { GridTemplate } from '@/styles/commonStyles';
 
 export default function MyPage() {
   return (

--- a/src/utils/formatData.ts
+++ b/src/utils/formatData.ts
@@ -1,0 +1,3 @@
+export const formatCurrency = (cost: number): string => {
+  return new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(cost).replace('₩', '');
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
       "@/mocks/*": ["src/mocks/*"],
       "@/pages/*": ["src/pages/*"],
       "@/styles/*": ["src/styles/*"],
-      "@/layouts/*": ["src/layouts/*"]
+      "@/layouts/*": ["src/layouts/*"],
+      "@/utils/*": ["src/utils/*"]
     }
   },
   "include": ["src"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       { find: '@/layouts', replacement: path.resolve(__dirname, 'src/layouts') },
       { find: '@/pages', replacement: path.resolve(__dirname, 'src/pages') },
       { find: '@/styles', replacement: path.resolve(__dirname, 'src/styles') },
+      { find: '@/utils', replacement: path.resolve(__dirname, 'src/utils') },
     ],
   },
   server: {


### PR DESCRIPTION
## 📌 주요 사항
- 피클 전체목록 카드 클릭 시 상세페이지로 이동하면서 피클 아이디 params로 가져와 상세피클데이터 받아오도록 하였습니다.
- 디자인이 나오지않아 간단히 데이터 잘 출력되는지 정도만 확인하였습니다.
- 참여하기 버튼 누르면 Pickle컴포넌트로 가게해서 결제로직으로 이동하게 하였습니다.
- 구현하다보니 404페이지 필요할 것 같아서 임시로 NotFoundPage 구현하였습니다! => 디자인 나오면 수정예정~

## 📷 스크린샷  

### 피클상세  
<p align="center" width: 100%>
 <img src="https://github.com/Splint-Final-Project/Pickle-Time-Frontend/assets/124874266/a9638aa2-9e14-45bb-a068-e1d82044bffb"  width="50%">   



---------------------------


### 404
<p align="center" width: 100%>
 <img src="https://github.com/Splint-Final-Project/Pickle-Time-Frontend/assets/124874266/5d3d443a-38bf-4202-9b1b-d248f4e9dea9"  width="50%">  




## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~



## #️⃣ 연관 이슈번호
이슈를 해결한 경우 👉🏻 close #39 
