### PR TITLE
바텀모달시트 기능추가 및 이용결제 약관 컴포넌트 기능 추가

### DIFF
--- a/src/components/common/modal/BottomSheetModal.tsx
+++ b/src/components/common/modal/BottomSheetModal.tsx
@@ -7,7 +7,12 @@ import useBottomSheetModal from '@/hooks/zustand/useBottomSheetModal';
 import CloseIcon from '@/assets/icons/CloseIcon';
 
 export default function BottomSheetModal() {
-  const { active: modalState, handleClose: closeModal, component: Component } = useBottomSheetModal(state => state);
+  const {
+    active: modalState,
+    handleClose: closeModal,
+    component: Component,
+    callback,
+  } = useBottomSheetModal(state => state);
 
   const potal = document.getElementById('modal-root') || document.createElement('div');
   const ref = useOutsideClick<HTMLDivElement>({ callback: closeModal, modalState });
@@ -32,7 +37,7 @@ export default function BottomSheetModal() {
           <S.DragBarWrap>
             <S.DragBar />
           </S.DragBarWrap>
-          <Component handleClose={closeModal} />
+          <Component handleClose={closeModal} callback={callback} />
         </S.Container>
       </S.BackLayout>,
       potal,

--- a/src/components/picklePayment/PaymentTerms .tsx
+++ b/src/components/picklePayment/PaymentTerms .tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import CheckIcon from '@/assets/icons/checkIcon.svg';
 import useBottomSheetModal from '@/hooks/zustand/useBottomSheetModal';
+import { useCallback, useRef } from 'react';
 
 interface PaymentTermsProps {
   setState: React.Dispatch<React.SetStateAction<boolean>>;
@@ -8,27 +9,41 @@ interface PaymentTermsProps {
 
 interface TermsContentProps {
   handleClose: () => void;
+  callback: () => void;
 }
 
 export default function PaymentTerms({ setState }: PaymentTermsProps) {
   const openBSModal = useBottomSheetModal(state => state.handleOpen);
+  const ref = useRef<HTMLInputElement>(null);
+  const handleModalBtnEvent = useCallback(() => {
+    if (ref.current) {
+      ref.current.checked = true;
+      setState(true);
+    }
+  }, [setState]);
   return (
     <>
       <S.Title>주문 내용 확인 및 결제 동의</S.Title>
       <S.Wrap>
         <S.Inner>
-          <S.Input id="terms-checkbox" type="checkbox" onChange={e => setState(e.target.checked)} />
+          <S.Input id="terms-checkbox" type="checkbox" onChange={e => setState(e.target.checked)} ref={ref} />
           <S.Label htmlFor="terms-checkbox" className="agree1">
             <span>[필수] 개인정보 수집 이용 동의</span>
           </S.Label>
         </S.Inner>
-        <S.ModalBtn onClick={() => openBSModal({ renderComponent: TermsContent })}>내용보기</S.ModalBtn>
+        <S.ModalBtn onClick={() => openBSModal({ renderComponent: TermsContent, callback: handleModalBtnEvent })}>
+          내용보기
+        </S.ModalBtn>
       </S.Wrap>
     </>
   );
 }
 
-function TermsContent({ handleClose }: TermsContentProps) {
+function TermsContent({ handleClose, callback }: TermsContentProps) {
+  const handleCheck = () => {
+    callback();
+    handleClose();
+  };
   return (
     <S.Container>
       <S.TermsTitle>개인정보 수입 및 이용</S.TermsTitle>
@@ -76,7 +91,7 @@ function TermsContent({ handleClose }: TermsContentProps) {
           개인정보 제공에 동의하지 않으실 수 있으며, 동의하지 않으실 경우 서비스 이용이 제한될 수 있습니다.
         </S.TermsDescription>
       </S.TableContainer>
-      <S.CheckBtn type="button" onClick={handleClose}>
+      <S.CheckBtn type="button" onClick={handleCheck}>
         확인하기
       </S.CheckBtn>
     </S.Container>
@@ -133,8 +148,7 @@ const S = {
     text-align: center;
   `,
   Container: styled.div`
-    min-width: 37.5rem;
-    width: 30vw;
+    width: 100%;
     display: flex;
     flex-direction: column;
     gap: 1.6rem;

--- a/src/hooks/zustand/useBottomSheetModal.ts
+++ b/src/hooks/zustand/useBottomSheetModal.ts
@@ -1,11 +1,17 @@
 import { ComponentType } from 'react';
 import { create } from 'zustand';
 
+interface ModalComponentsProps {
+  handleClose: () => void;
+  callback: (() => void) | null;
+}
+
 interface ModalState {
   active: boolean;
-  handleOpen: ({ renderComponent }: { renderComponent: ComponentType<any> }) => void;
+  handleOpen: ({ renderComponent, callback }: { renderComponent: ComponentType<any>; callback?: () => void }) => void;
   handleClose: () => void;
-  component: ComponentType<any> | null;
+  component: ComponentType<ModalComponentsProps> | null;
+  callback: (() => void) | null;
 }
 /**
  *
@@ -42,9 +48,10 @@ interface ModalState {
 */
 const useBottomSheetModal = create<ModalState>()(set => ({
   active: false,
-  handleOpen: ({ renderComponent }) => set(() => ({ active: true, component: renderComponent })),
-  handleClose: () => set(() => ({ active: false, component: null })),
+  handleOpen: ({ renderComponent, callback }) => set(() => ({ active: true, component: renderComponent, callback })),
+  handleClose: () => set(() => ({ active: false, component: null, callback: null })),
   component: null,
+  callback: null,
 }));
 
 export default useBottomSheetModal;


### PR DESCRIPTION
## 📌 주요 사항
- 바텀시트모달의 기능을 추가하였습니다.
- 이제 바텀시트 모달을 오픈할 때 callback함수를 전달할 수 있으며 이 함수는 바텀시트 모달안에 들어가는 컴포넌트에 props로 들어갑니다
- 이를 이용해 결제약관 모달을 보고 확인하기 버튼을 눌렀을 때 인풋이 체크가 되게 구현하였습니다

## 📷 스크린샷  
구현한 부분 첨부  


https://github.com/Splint-Final-Project/Pickle-Time-Frontend/assets/143431179/861c5cc0-1421-4326-8b6d-fb427e16998b



## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~



## #️⃣ 연관 이슈번호
이슈를 해결한 경우 👉🏻 close #이슈번호
