### PR TITLE
[내 주변] 가까운 피클 목록 카드 컴포넌트 구현

### DIFF
--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -64,7 +64,7 @@ export default function BottomNav() {
       <S.NavItem to={routes.home} isActive={location.pathname === routes.home}>
         <S.Icon src="/icons/bottomNavbar/home.svg" alt="Home" />홈
       </S.NavItem>
-      <S.NavItem to={routes.pickle} isActive={location.pathname === routes.pickle}>
+      <S.NavItem to={routes.around} isActive={location.pathname === routes.around}>
         <S.Icon src="/icons/bottomNavbar/marker.svg" alt="Marker" />내 주변
       </S.NavItem>
       <S.NavItem to={routes.myPickles} isActive={location.pathname === routes.myPickles}>

--- a/src/components/picklecard/AroundPickleCard.tsx
+++ b/src/components/picklecard/AroundPickleCard.tsx
@@ -1,0 +1,108 @@
+import styled from '@emotion/styled';
+import HeartButton from '@/components/common/button/HeartButton';
+import { useDeletePickleLikeMutation, useGetLikeCount, usePickleLikeMutation } from '@/hooks/query/like';
+import { When } from '@/apis/types/pickles.type';
+import { formatCurrency, formatDays, formatPeriod } from '@/utils/formatData';
+
+interface AroundPickleProps {
+  pickleId: string;
+  title: string;
+  imgUrl: string;
+  when: When;
+  cost: number;
+}
+
+export default function AroundPickleCard({ pickleId, title, imgUrl, when, cost }: AroundPickleProps) {
+  const { data } = useGetLikeCount(pickleId);
+  const { mutate: postLikeMutate } = usePickleLikeMutation(pickleId);
+  const { mutate: deleteLikeMutate } = useDeletePickleLikeMutation(pickleId);
+
+  const handleHeartClick = (event: any) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (data && data.data.length) {
+      deleteLikeMutate();
+    } else if (data && !data.data.length) {
+      postLikeMutate();
+    }
+  };
+
+  const date = formatPeriod(when);
+  const days = formatDays(when);
+
+  //TODO: 하트가 이미지 위에서 잘 안보이기 때문에 EmptyHeart에 border 좀 더 밝은색 띄울 수 있도록 해야함
+  return (
+    <S.Container>
+      <HeartButton
+        isActive={data?.data.isClicked}
+        onClick={handleHeartClick}
+        size={20}
+        style={{ position: 'absolute', top: '1rem', right: '1rem' }}
+      />
+      <S.ThumbnailImg src={imgUrl} alt="피클 이미지" />
+      <S.TextInfoBox>
+        <S.Title>{title}</S.Title>
+        <S.BottomText>
+          <S.Time>
+            <span className="date">{date}</span>
+            <span className="days">{days}</span>
+          </S.Time>
+          <S.Cost>{formatCurrency(cost)}원</S.Cost>
+        </S.BottomText>
+      </S.TextInfoBox>
+    </S.Container>
+  );
+}
+
+const S = {
+  Container: styled.div`
+    position: relative;
+    max-width: 32.2rem;
+    border-radius: 1.2rem;
+    box-shadow: 0 0 1rem 0 rgba(0, 0, 0, 0.05);
+  `,
+
+  ThumbnailImg: styled.img`
+    width: 100%;
+    height: 12.3rem;
+    object-fit: cover;
+    border-top-left-radius: 1.2rem;
+    border-top-right-radius: 1.2rem;
+    background-color: #ccc;
+  `,
+
+  TextInfoBox: styled.div`
+    padding: 1.5rem 1.7rem 2rem 1.7rem;
+  `,
+
+  Title: styled.span`
+    color: #292929;
+    ${({ theme }) => theme.typography.subTitle2}
+  `,
+
+  BottomText: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    margin-top: 0.5rem;
+    color: ${({ theme }) => theme.color.sub};
+  `,
+
+  Time: styled.div`
+    & .date {
+      ${({ theme }) => theme.typography.body1};
+      margin-right: 0.6rem;
+    }
+
+    & .days {
+      ${({ theme }) => theme.typography.body2}
+    }
+  `,
+
+  Cost: styled.span`
+    color: #292929;
+    ${({ theme }) => theme.typography.subTitle2}
+  `,
+};

--- a/src/pages/around/AroundMe.tsx
+++ b/src/pages/around/AroundMe.tsx
@@ -1,9 +1,32 @@
-import React from 'react';
+import AroundPickleCard from '@/components/picklecard/AroundPickleCard';
+import { useGetNearbyPickles } from '@/hooks/query/pickles';
 
 /**
  * 내 주변 페이지
  */
 
 export default function AroundMe() {
-  return <div>AroundMe</div>;
+  // 임시 location
+  const location = {
+    latitude: 37.5415662783673,
+    longitude: 127.017393782846,
+  };
+  const { data } = useGetNearbyPickles(location);
+  const nearbyPickle = data?.data;
+
+  return (
+    <>
+      {nearbyPickle.map(pickle => (
+        <AroundPickleCard
+          pickleId={pickle?.id}
+          title={pickle?.title}
+          //TODO : 데이터에 아직 안들어가서 아래 임시 링크 쓴거에요! 서버 데이터 바뀌면 이거사용하고 아래지워주세요~
+          // imgUrl={pickle?.imgUrl}
+          imgUrl="https://avatars.githubusercontent.com/u/124874266?v=4"
+          when={pickle?.when}
+          cost={pickle?.cost}
+        />
+      ))}
+    </>
+  );
 }


### PR DESCRIPTION
## 📌 주요 사항
- 내 주변에서 쓰일 목록 카드 컴포넌트 만들었습니다.
- 일단 around로 경로 설정했고 하단 네비게이션바에서도 pickle로 되어있던거 변경했습니다.
- `useGetNearbyPickles`를 통해 받아온 주변 피클 목록 데이터에 `imgUrl`이 누락되어 있어서 서버 수정되면 넣으면 될 것 같습니다.
- 일부러 카드 넓이는 마커 클릭시 하나의 카드만 뜬다고 가정했을 때를 생각하고 피그마대로만 했어요.
   옆으로 넓으면 굳이(?)일 것 같고 안 예쁠 것 같아서 max-width뒀는데 이어서 구현하실 때 필요에 따라 변경하시면 될 것 같습니다.
- 하트 아이콘이 이미지 위로 띄워지면서 기존 `EmptyHeart` 아이콘이 연회색이라 잘 안보입니다.
   fill관련해서 props줘서 더 밝게해서 잘 보이게 하면 될 것 같습니다.

## 📷 스크린샷  

![165E5CA0-B737-40A8-90B5-D935880518BF](https://github.com/Splint-Final-Project/Pickle-Time-Frontend/assets/124874266/e50723aa-adfe-4b3b-8b46-18bd0c7b7186)


## 💬 리뷰 시 요구사항![선택]
@vinoankr 님 카드 컴포넌트 가져가셔서 내 주변 구현해주시면 될 것 같습니닷!



## #️⃣ 연관 이슈번호
이슈를 해결한 경우 👉🏻 close #89 
