### PR TITLE
fix: 메시지 페이지네이션 수정, 최신 페이지에 새로운 메시지 누적되지 않는 버그 수정

### DIFF
--- a/src/hooks/query/messages/index.ts
+++ b/src/hooks/query/messages/index.ts
@@ -83,7 +83,7 @@ export const useMessageSocket = (socket: any, conversationId: string) => {
         // 최신 데이터를 기반으로 상태 업데이트
         const updatedPages = oldData.pages.map((page: any, index: number) => {
           // 마지막 페이지에 새로운 메시지를 추가
-          if (index === oldData.pages.length - 1) {
+          if (index === 0) {
             return {
               ...page,
               messages: [...page.messages, newMessage],

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -27,7 +27,7 @@ function useIntersectionObserver(callback: () => void, loaderRef: RefObject<Elem
 
     const unobserve = observe(loaderRef.current);
     return unobserve;
-  }, [loaderRef, callback]);
+  }, [loaderRef]);
 }
 
 export default useIntersectionObserver;

--- a/src/pages/chat/Conversation.page.tsx
+++ b/src/pages/chat/Conversation.page.tsx
@@ -51,6 +51,7 @@ export default function Conversation() {
   };
 
   const goBack = () => {
+    messageObserverRef.current = null;
     navigate(`${routes.chatList}`);
   };
 


### PR DESCRIPTION
## 📌 주요 사항
- 페이지네이션 버그를 수정: 가장 최신 페이지에 누적되도록 수정
- 불필요한 의존성 배열 제거

## 📷 스크린샷  
구현한 부분 첨부  



## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~



## #️⃣ 연관 이슈번호
이슈를 해결한 경우 👉🏻 close #이슈번호
